### PR TITLE
Add responsive utils with breakpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,14 @@
     "polished": "^4.0.5",
     "react": "17.0.1",
     "react-dom": "17.0.1",
+    "styled-breakpoints": "^9.0.8",
     "styled-components": "^5.2.1",
     "styled-normalize": "^8.0.7"
+  },
+  "jest": {
+    "setupFilesAfterEnv": [
+      "<rootDir>/setupTests.ts"
+    ]
   },
   "devDependencies": {
     "@testing-library/react": "^11.2.2",

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -1,0 +1,1 @@
+import 'jest-styled-components'

--- a/style/responsive.spec.tsx
+++ b/style/responsive.spec.tsx
@@ -1,0 +1,16 @@
+import 'jest-styled-components'
+import { uniformScale } from './responsive'
+
+describe('uniformScale', () => {
+  test('should return correct value when supplied PX unit', () => {
+    expect(uniformScale('10px', 'xxl')).toMatch('0.45454545454545453vw')
+  })
+
+  test('should return correct value when supplied EM unit', () => {
+    expect(uniformScale('10em', 'xxl')).toMatch('7.2727272727272725vw')
+  })
+
+  test('should return correct value when supplied REM unit', () => {
+    expect(uniformScale('10rem', 'xxl')).toMatch('7.2727272727272725vw')
+  })
+})

--- a/style/responsive.spec.tsx
+++ b/style/responsive.spec.tsx
@@ -1,4 +1,3 @@
-import 'jest-styled-components'
 import { uniformScale } from './responsive'
 
 describe('uniformScale', () => {

--- a/style/responsive.tsx
+++ b/style/responsive.tsx
@@ -1,0 +1,54 @@
+import { getValueAndUnit } from 'polished'
+import { down, Orientation, Props, up, between } from 'styled-breakpoints'
+import { baseFontSize } from './typography'
+
+export const breakpoints = {
+  xxs: '480px',
+  xs: '600px',
+  sm: '900px',
+  md: '1200px',
+  lg: '1500px',
+  xl: '1800px',
+  xxl: '2200px',
+}
+
+type BreakpointName = keyof typeof breakpoints
+export type BreakpointList = Record<BreakpointName, string>
+
+export function uniformScale(
+  cssValue: string,
+  targetMediaQuery: BreakpointName
+): string {
+  // Split into value and unit
+  const [value, unit] = getValueAndUnit(cssValue)
+  const breakpoint = breakpoints[targetMediaQuery]
+
+  // Convert from relative to px value
+  const convertedUnit = unit === 'px' ? value : value * baseFontSize
+
+  const [bpValue] = getValueAndUnit(breakpoint)
+
+  return `${convertedUnit / (bpValue * 0.01 * 1)}vw`
+}
+
+export function inclusiveDown(
+  maxWidth: Exclude<BreakpointName, 'xxl'>,
+  orientation?: Orientation
+): () => (props: Props) => string {
+  return () => down(maxWidth, orientation)
+}
+
+export function inclusiveUp(
+  minWidth: BreakpointName,
+  orientation?: Orientation
+): () => (props: Props) => string {
+  return () => up(minWidth, orientation)
+}
+
+export function inclusiveBetween(
+  minWidth: BreakpointName,
+  maxWidth: Exclude<BreakpointName, 'xxl'>,
+  orientation?: Orientation
+): () => (props: Props) => string {
+  return () => between(minWidth, maxWidth, orientation)
+}

--- a/style/theme.ts
+++ b/style/theme.ts
@@ -1,5 +1,6 @@
 import { hsl } from 'polished'
 import { css, CSSProp, DefaultTheme, ThemeProps } from 'styled-components'
+import { BreakpointList, breakpoints } from './responsive'
 
 export type ThemeName = 'light' | 'dark'
 
@@ -13,6 +14,7 @@ export type Theme = {
   background: Record<LimitedShadeRange, string>
   accent: Record<ColourRange, string>
   positive: Record<ColourRange, string>
+  breakpoints: BreakpointList
 }
 
 const common = {
@@ -26,6 +28,7 @@ const common = {
     light: hsl(115, 0.64, 0.65),
     dark: hsl(115, 0.65, 0.3),
   },
+  breakpoints: breakpoints,
 }
 
 /* Light

--- a/style/utils.spec.tsx
+++ b/style/utils.spec.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import 'jest-styled-components'
 import styled from 'styled-components'
 import {
   createHsl,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6711,6 +6711,11 @@ style-value-types@3.2.0, style-value-types@^3.2.0:
     hey-listen "^1.0.8"
     tslib "^1.10.0"
 
+styled-breakpoints@^9.0.8:
+  version "9.0.8"
+  resolved "https://registry.yarnpkg.com/styled-breakpoints/-/styled-breakpoints-9.0.8.tgz#4755601c7d2fb465931a7905ab86b49c8442cca5"
+  integrity sha512-b/T1aU6O9IeN4RjCAnMcDYoeWkmzN4ewPWOG26VnTTE14lSyilSS2RhIl2tvc1brQ2ZvSR7oR9Wn9fq2/dURDA==
+
 styled-components@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.2.1.tgz#6ed7fad2dc233825f64c719ffbdedd84ad79101a"


### PR DESCRIPTION
Important to note that `styled-breakpoints` uses inclusive ranges with isn't common, wrapped up in their own utility functions to make them type safe and self documenting of this.