### PR TITLE
Fix font flicker on render change

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,6 +6,9 @@ import GlobalStyle from '../style/global'
 import { FocusVisibleManager } from '../hooks/useFocusVisible/useFocusVisible'
 import { darkTheme } from '../style/theme'
 
+// Import fonts outside of styled-components to avoid flicker on state change
+import '../style/font.css'
+
 function App({ Component, pageProps }: AppProps): JSX.Element {
   return (
     <>

--- a/style/font.css
+++ b/style/font.css
@@ -1,0 +1,6 @@
+@font-face {
+  font-family: 'Manrope';
+  src: url('/manrope-variable.ttf');
+  font-weight: 1 999;
+  font-display: swap;
+}

--- a/style/global.tsx
+++ b/style/global.tsx
@@ -158,22 +158,12 @@ const GlobalDocumentAdjustment = createGlobalStyle`
   }
 `
 
-const Font = createGlobalStyle`
-  @font-face {
-    font-family: 'Manrope';
-    src: url('/manrope-variable.ttf');
-    font-weight: 1 999;
-    font-display: swap;
-  }
-`
-
 const GlobalStyle: React.FunctionComponent = () => {
   return (
     <>
       <Normalize />
       <Global />
       <GlobalDocumentAdjustment />
-      <Font />
     </>
   )
 }


### PR DESCRIPTION
Application of `@font-face` via `createGlobalStyle` causes a flicker on re-renders, moving to a standard css import fixes this issue.

Before



https://user-images.githubusercontent.com/11708259/104094391-96904800-5288-11eb-881c-366ce071246b.mov

After

https://user-images.githubusercontent.com/11708259/104094390-91cb9400-5288-11eb-9969-d9861132785f.mov






