### PR TITLE
Add dominant image colour

### DIFF
--- a/components/ImageBase/ImageBase.tsx
+++ b/components/ImageBase/ImageBase.tsx
@@ -12,6 +12,7 @@ type ImageBaseProps = {
   alt?: string
   scaleRender?: number
   scaleRenderFromBp?: [BreakpointName, number]
+  backgroundColor?: string
 }
 
 function ImageBase({
@@ -20,6 +21,7 @@ function ImageBase({
   height,
   alt,
   scaleRender = 100,
+  backgroundColor,
   scaleRenderFromBp,
 }: ImageBaseProps): JSX.Element {
   const { background } = useTheme()
@@ -57,7 +59,7 @@ function ImageBase({
   return (
     <div
       css={`
-        background-color: ${background('medium')};
+        background-color: ${backgroundColor || background('medium')};
       `}
     >
       <motion.div

--- a/components/MoreWork/MoreWork.tsx
+++ b/components/MoreWork/MoreWork.tsx
@@ -70,6 +70,7 @@ function MoreWork({ currentWorkName }: MoreWorkProps): JSX.Element {
                         src={thumbnailImageSmall.src}
                         width={thumbnailImageSmall.width}
                         height={thumbnailImageSmall.height}
+                        backgroundColor={thumbnailImageSmall.dominantColor}
                         scaleRenderFromBp={['sm', 50]}
                       />
                     </div>

--- a/components/WorkGrid/WorkGrid.tsx
+++ b/components/WorkGrid/WorkGrid.tsx
@@ -52,6 +52,7 @@ function WorkGrid(): JSX.Element {
                     description={description}
                     width={thumbnailImage.width}
                     height={thumbnailImage.height}
+                    backgroundColor={thumbnailImage.dominantColor}
                   />
                 </div>
               )

--- a/components/WorkGrid/WorkGridItem.tsx
+++ b/components/WorkGrid/WorkGridItem.tsx
@@ -17,6 +17,7 @@ type WorkGridItemProps = {
   width: number
   height: number
   href: string
+  backgroundColor: string
 }
 
 function WorkGridItem({
@@ -27,6 +28,7 @@ function WorkGridItem({
   width,
   height,
   href,
+  backgroundColor,
 }: WorkGridItemProps): JSX.Element {
   const { foreground } = useTheme()
 
@@ -51,6 +53,7 @@ function WorkGridItem({
             width={width}
             height={height}
             scaleRenderFromBp={['sm', 70]}
+            backgroundColor={backgroundColor}
           />
         </div>
 

--- a/components/WorkTemplate/WorkTemplate.tsx
+++ b/components/WorkTemplate/WorkTemplate.tsx
@@ -125,6 +125,7 @@ function WorkTemplate({
               src={heroImage.src}
               width={heroImage.width}
               height={heroImage.height}
+              backgroundColor={heroImage.dominantColor}
             />
           </div>
         </header>

--- a/data/work.ts
+++ b/data/work.ts
@@ -4,6 +4,7 @@ type ImageData = {
   src: string
   width: number
   height: number
+  dominantColor: string
 }
 
 type WorkDetails = {
@@ -48,16 +49,19 @@ export const WORK: Record<WorkName, WorkDetails> = {
       src: '/images/aragon-hero.png',
       width: 3136,
       height: 1435,
+      dominantColor: '#00C1F0',
     },
     thumbnailImage: {
       src: '/images/aragon-thumb.png',
       width: 1986,
       height: 1451,
+      dominantColor: '#00C1F0',
     },
     thumbnailImageSmall: {
       src: '/images/aragon-thumb-small.png',
       width: 1985,
       height: 1304,
+      dominantColor: '#00C1F0',
     },
   },
   bright: {
@@ -79,16 +83,19 @@ export const WORK: Record<WorkName, WorkDetails> = {
       src: '/images/bright-hero.png',
       width: 3136,
       height: 1435,
+      dominantColor: '#7500BF',
     },
     thumbnailImage: {
       src: '/images/bright-thumb.png',
       width: 1986,
       height: 2131,
+      dominantColor: '#7500BF',
     },
     thumbnailImageSmall: {
       src: '/images/bright-thumb-small.png',
       width: 1985,
       height: 1304,
+      dominantColor: '#7500BF',
     },
   },
   brandwatch: {
@@ -104,16 +111,19 @@ export const WORK: Record<WorkName, WorkDetails> = {
       src: '/images/brandwatch-hero.png',
       width: 3136,
       height: 1435,
+      dominantColor: '#762D82',
     },
     thumbnailImage: {
       src: '/images/brandwatch-thumb.png',
       width: 1986,
       height: 2489,
+      dominantColor: '#762D82',
     },
     thumbnailImageSmall: {
       src: '/images/brandwatch-thumb-small.png',
       width: 1985,
       height: 1304,
+      dominantColor: '#762D82',
     },
   },
   blocks: {
@@ -136,16 +146,19 @@ export const WORK: Record<WorkName, WorkDetails> = {
       src: '/images/blocks-hero.png',
       width: 3136,
       height: 1435,
+      dominantColor: '#1F2428',
     },
     thumbnailImage: {
       src: '/images/blocks-thumb.png',
       width: 1986,
       height: 1889,
+      dominantColor: '#1F2428',
     },
     thumbnailImageSmall: {
       src: '/images/blocks-thumb-small.png',
       width: 1985,
       height: 1304,
+      dominantColor: '#1F2428',
     },
   },
 }


### PR DESCRIPTION
Fill image placeholders with a dominant image colour for a smoother lazy load experience.

While this could be automated easily by analysing the image palette on the client, there is little reason to add complexity with such a small number of assets right now.

https://user-images.githubusercontent.com/11708259/106359607-b062ff00-630b-11eb-9e67-9e5577319e05.mov

